### PR TITLE
Add clear to end of screen

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ const scroll = {
 
 const erase = {
   screen: `${CSI}2J`,
+  screenEnd: `${CSI}0J`,
   up: (count = 1) => `${CSI}1J`.repeat(count),
   down: (count = 1) => `${CSI}J`.repeat(count),
   line: `${CSI}2K`,

--- a/src/sisteransi.d.ts
+++ b/src/sisteransi.d.ts
@@ -25,6 +25,7 @@ export namespace scroll {
 
 export namespace erase {
     export const screen: string;
+    export const screenEnd: string;
     export const line: string;
     export const lineEnd: string;
     export const lineStart: string;


### PR DESCRIPTION
This is useful if you want to clear from your cursor, down to the end of the screen, without needing to know what is below you to know how far down to go to clear lines.