### PR TITLE
Parameters in types that should be optional

### DIFF
--- a/src/sisteransi.d.ts
+++ b/src/sisteransi.d.ts
@@ -8,7 +8,7 @@ export namespace cursor {
     export const save: string;
     export const restore: string;
 
-    export function to(x: number, y: number): string;
+    export function to(x: number, y?: number): string;
     export function move(x: number, y: number): string;
     export function up(count: number): string;
     export function down(count: number): string;

--- a/src/sisteransi.d.ts
+++ b/src/sisteransi.d.ts
@@ -10,17 +10,17 @@ export namespace cursor {
 
     export function to(x: number, y?: number): string;
     export function move(x: number, y: number): string;
-    export function up(count: number): string;
-    export function down(count: number): string;
-    export function forward(count: number): string;
-    export function backward(count: number): string;
-    export function nextLine(count: number): string;
-    export function prevLine(count: number): string;
+    export function up(count?: number): string;
+    export function down(count?: number): string;
+    export function forward(count?: number): string;
+    export function backward(count?: number): string;
+    export function nextLine(count?: number): string;
+    export function prevLine(count?: number): string;
 }
 
 export namespace scroll {
-    export function up(count: number): string;
-    export function down(count: number): string;
+    export function up(count?: number): string;
+    export function down(count?: number): string;
 }
 
 export namespace erase {
@@ -29,7 +29,7 @@ export namespace erase {
     export const lineEnd: string;
     export const lineStart: string;
 
-    export function up(count: number): string;
-    export function down(count: number): string;
+    export function up(count?: number): string;
+    export function down(count?: number): string;
     export function lines(count: number): string;
 }


### PR DESCRIPTION
There were several function parameters in the type definitions that should be optional, based on their usage and the execution of the function(s).