### PR TITLE
Added a method to clear the terminal screen (viewport)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
-pacckage-lock.json
+package-lock.json
+.idea

--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,12 @@ Erase from the current cursor position to the start of the current line.
 Erase from the current cursor position up the specified amount of rows.
 
 
+### clear
+
+#### screen
+Clear the terminal screen. (Viewport)
+
+
 ## Credit
 
 This is a fork of [ansi-escapes](https://github.com/sindresorhus/ansi-escapes).

--- a/src/index.js
+++ b/src/index.js
@@ -55,4 +55,8 @@ const erase = {
   }
 }
 
-module.exports = { cursor, scroll, erase, beep };
+const clear = {
+  screen: `${ESC}c`
+}
+
+module.exports = { cursor, scroll, erase, beep, clear };

--- a/src/sisteransi.d.ts
+++ b/src/sisteransi.d.ts
@@ -1,5 +1,4 @@
 export const beep: string;
-export const clear: string;
 
 export namespace cursor {
     export const left: string;
@@ -32,4 +31,8 @@ export namespace erase {
     export function up(count?: number): string;
     export function down(count?: number): string;
     export function lines(count: number): string;
+}
+
+export namespace clear {
+    export const screen: string;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -4,9 +4,9 @@ const test = require('tape');
 const ansi = require('../src');
 
 test('basic', t => {
-  t.plan(6);
+  t.plan(7);
   t.equal(typeof ansi, 'object');
-  let expect = ['cursor', 'scroll', 'erase', 'beep'];
+  let expect = ['cursor', 'scroll', 'erase', 'beep', 'clear'];
   expect.forEach(x => t.equal(x in ansi, true));
   t.equal(typeof ansi.beep, 'string');
 });
@@ -85,4 +85,11 @@ test('erase', t => {
   t.equal(e.down(2), `\x1b[J\x1b[J`);
   t.equal(e.down(0), ``);
   t.equal(e.lines(2), '\x1b[2K\x1b[1A\x1b[2K\x1b[G');
+});
+
+test('clear', t => {
+  t.plan(2);
+  let c = ansi.clear;
+  t.equal(typeof c, 'object');
+  t.equal(typeof c.screen, 'string');
 });


### PR DESCRIPTION
* Fixed a typo in the `.gitignore`
* Added test, type definition for `clear` API
* Documented the `clear` API usage

Inspired by - https://github.com/sindresorhus/ansi-escapes#clearscreen